### PR TITLE
Nesting modifiers

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -81,9 +81,19 @@ class Lexer {
         let postCount = 0;
         
         while (this.consume(modifier)) preCount++;
-        while (!this.match(modifier) && !this.match('\n') && !this.isAtEnd()) this.advance();
+        
+        const children = [];
+        while (!this.match(modifier) && !this.match('\n') && !this.isAtEnd()) {
+            const child = this.scanChildren();
+            if (child) {
+                children.push(child);
+            } else {
+                this.advance();
+            }
+        }
+
         while (this.consume(modifier)) postCount++;
-            
+
         if (preCount < 1 || postCount < 1) return false;
 
         /* 
@@ -111,7 +121,7 @@ class Lexer {
             if (postCount > 2) this.rollback(2);
         }
 
-        return makeToken(type, raw, text, [], {});
+        return makeToken(type, raw, text, children, {});
     }
 
     scanAnchor() {

--- a/lib/transpiler.js
+++ b/lib/transpiler.js
@@ -49,17 +49,23 @@ class Transpiler {
 
     compileStrong() {
         // console.debug("Transpiler:compileStrong");
-        return wrap(this.peekLast().text, TOKEN_BOLD);
+        const token = this.peekLast();
+        const text = this.compileChildren(token.text, token.children);
+        return wrap(text, TOKEN_BOLD);
     }
 
     compileItalic() {
         // console.debug("Transpiler:compileItalics");
-        return wrap(this.peekLast().text, TOKEN_ITAL);
+        const token = this.peekLast();
+        const text = this.compileChildren(token.text, token.children);
+        return wrap(text, TOKEN_ITAL);
     }
 
     compileStrikethrough() {
         // console.debug("Transpiler:compileIStrikeThrough");
-        return wrap(this.peekLast().text, TOKEN_STRIKE);
+        const token = this.peekLast();
+        const text = this.compileChildren(token.text, token.children);
+        return wrap(text, TOKEN_STRIKE);
     }
 
     compileAnchor() {


### PR DESCRIPTION
Added support for nesting modifiers. Examples:

`_Italic **and bold**_` => _Italic **and bold**_
`~*all* __crossed *out*__~` => ~*all* __crossed *out*__~